### PR TITLE
feat: Règle d'affichage du lien vers LaBonneAlternance

### DIFF
--- a/ui/src/pages/Formation/Formation.js
+++ b/ui/src/pages/Formation/Formation.js
@@ -54,6 +54,14 @@ const Formation = ({ formation }) => {
   //   ? (args) => <WarningBox data-testid={"adress-warning"} {...args} />
   //   : React.Fragment;
 
+  const now = new Date();
+  // si date du jour < septembre : nous afficherons les formations ayant des tag sur année -1, année en cours et année + 1
+  // si date du jour >= septembre : année en cours et année + 1, année +2
+  const tagsForLBA =
+    now.getMonth() >= 8
+      ? [now.getFullYear(), now.getFullYear() + 1, now.getFullYear() + 2]
+      : [now.getFullYear() - 1, now.getFullYear(), now.getFullYear() + 1];
+
   return (
     <Box borderRadius={4}>
       <Grid templateColumns="repeat(12, 1fr)">
@@ -69,7 +77,7 @@ const Formation = ({ formation }) => {
               Lieu de la formation
             </Heading>
             <Box mt={2} mb={4} ml={[-2, -2, -3]}>
-              {formation.catalogue_published && (
+              {formation.catalogue_published && formation.tags.some((tag) => tagsForLBA.includes(+tag)) && (
                 <Link href={getLBAUrl(formation)} textStyle="rf-text" variant="pill" isExternal>
                   voir sur labonnealternance <ExternalLinkLine w={"0.75rem"} h={"0.75rem"} mb={"0.125rem"} />
                 </Link>


### PR DESCRIPTION
1— Mise à jour des URL de redirection du catalogue vers LBA :
https://labonnealternance.pole-emploi.fr/ => https://labonnealternance.apprentissage.beta.gouv.fr/ 

2— En complément, LBA ne référence plus les formations qui ne possèdent que des tag antérieurs ou égaux à l'année scolaire en cours moins 2 ans.
Ainsi, si date du jour < septembre :  les formations ayant des tag sur année -1, année en cours et année + 1 sont affichées
si date du jour >= septembre : année en cours et année + 1, année +2
Exemples :
au 02/03/23 on récupère les formations 2022, 2023 et 2024
au 15/10/23 on récupère les formations 2023, 2024 et 2025

On peut donc supprimer les liens vers LBA sur les formations non référencées.