### PR TITLE
Fix/format csv

### DIFF
--- a/ui/src/common/components/Search/components/ExportButton.js
+++ b/ui/src/common/components/Search/components/ExportButton.js
@@ -25,7 +25,7 @@ const serializeObject = (columns, obj) => {
     } else {
       value = `${value}`.trim().replace(/"/g, "'").replace(/;/g, ",").replace(/\n/g, "").replace(/\r/g, "");
     }
-    res.push(value !== "" ? `=${value}"` : "");
+    res.push(value !== "" ? `"${value}"` : "");
   });
   return res.join(CSV_SEPARATOR);
 };

--- a/ui/src/common/components/Search/components/ExportButton.js
+++ b/ui/src/common/components/Search/components/ExportButton.js
@@ -25,7 +25,7 @@ const serializeObject = (columns, obj) => {
     } else {
       value = `${value}`.trim().replace(/"/g, "'").replace(/;/g, ",").replace(/\n/g, "").replace(/\r/g, "");
     }
-    res.push(value !== "" ? `="${value}"` : "");
+    res.push(value !== "" ? `=${value}"` : "");
   });
   return res.join(CSV_SEPARATOR);
 };


### PR DESCRIPTION
L'export depuis les pages de recherche contient des champs au format `="field"`. 
Bien que ce soit ok pour excel, numbers, et autres, cela peut poser des problèmes lors de l'import de ces fichiers via des scripts.
Ce commit supprime le `=`.